### PR TITLE
Material-Sort Rendering and UI Improvements

### DIFF
--- a/SHOE/Headers/AssetManager.h
+++ b/SHOE/Headers/AssetManager.h
@@ -111,6 +111,9 @@ public:
 
 	void Initialize(Microsoft::WRL::ComPtr<ID3D11Device> device, Microsoft::WRL::ComPtr<ID3D11DeviceContext> context);
 
+	// Called whenever a material changes, or when a GameEntity is added
+	void SortEntitiesByMaterial();
+
 	// Methods to create new assets
 
 	std::shared_ptr<GameEntity> CreateGameEntity(std::shared_ptr<Mesh> mesh, std::shared_ptr<Material> mat, std::string name = "GameEntity");
@@ -239,8 +242,18 @@ public:
 	std::shared_ptr<Emitter> GetEmitterAtID(int id);
 	FMOD::Sound* GetSoundAtID(int id);
 	std::shared_ptr<Camera> GetCameraAtID(int id);
+	std::shared_ptr<Material> GetMaterialAtID(int id);
+	std::shared_ptr<Mesh> GetMeshAtID(int id);
+	std::shared_ptr<SimpleVertexShader> GetVertexShaderAtID(int id);
+	std::shared_ptr<SimplePixelShader> GetPixelShaderAtID(int id);
+	std::shared_ptr<SimpleComputeShader> GetComputeShaderAtID(int id);
 	std::shared_ptr<GameEntity> GetTerrainAtID(int id);
+	std::shared_ptr<GameEntity> GetGameEntityByID(int id);
 	std::shared_ptr<Sky> GetSkyAtID(int id);
+
+	// Asset internals set functions
+	void SetGameEntityMesh(std::shared_ptr<GameEntity> entity, std::shared_ptr<Mesh> newMesh);
+	void SetGameEntityMaterial(std::shared_ptr<GameEntity> entity, std::shared_ptr<Material> newMaterial);
 
 	inline std::wstring ConvertToWide(const std::string& as);
 

--- a/SHOE/Headers/Game.h
+++ b/SHOE/Headers/Game.h
@@ -77,6 +77,9 @@ private:
 	bool rtvWindowEnabled;
 	bool soundWindowEnabled;
 	bool camWindowEnabled;
+
+	// Transfer these to static locals
+	// Then add helper functions for setting them?
 	int entityUIIndex;
 	int terrainUIIndex;
 	int emitterUIIndex;

--- a/SHOE/Headers/GameEntity.h
+++ b/SHOE/Headers/GameEntity.h
@@ -16,6 +16,9 @@ private:
 	std::shared_ptr<Material> mat;
 	std::string name;
 	bool enabled;
+
+	void SetMaterial(std::shared_ptr<Material> newMaterial);
+	void SetMesh(std::shared_ptr<Mesh> newMesh);
 public:
 	GameEntity(std::shared_ptr<Mesh> mesh, DirectX::XMMATRIX worldIn, std::shared_ptr<Material> mat, std::string name = "GameObject");
 	~GameEntity();
@@ -32,6 +35,7 @@ public:
 
 	void Draw(Microsoft::WRL::ComPtr<ID3D11DeviceContext> context, std::shared_ptr<Camera> cam, std::shared_ptr<Camera> shadowCam1, std::shared_ptr<Camera> shadowCam2);
 	void DrawFromVerts(Microsoft::WRL::ComPtr<ID3D11DeviceContext> context, std::shared_ptr<SimpleVertexShader> vs, std::shared_ptr<Camera> cam, std::shared_ptr<Camera> shadowCam1, std::shared_ptr<Camera> shadowCam2);
-	//void GenShadows(Microsoft::WRL::ComPtr<ID3D11DeviceContext> context, std::shared_ptr<Camera> shadowCam);
+
+	friend class AssetManager;
 };
 

--- a/SHOE/Headers/Renderer.h
+++ b/SHOE/Headers/Renderer.h
@@ -1,6 +1,44 @@
 #include "GameEntity.h"
 #include "AssetManager.h"
 
+#define MAX_LIGHTS 64
+
+// These need to match the expected per-frame/object/material vertex shader data
+struct VSPerFrameData
+{
+    DirectX::XMFLOAT4X4 ViewMatrix;
+    DirectX::XMFLOAT4X4 ProjectionMatrix;
+    DirectX::XMFLOAT4X4 LightViewMatrix;
+    DirectX::XMFLOAT4X4 LightProjectionMatrix;
+    DirectX::XMFLOAT4X4 EnvLightViewMatrix;
+    DirectX::XMFLOAT4X4 EnvLightProjectionMatrix;
+};
+
+struct VSPerMaterialData
+{
+    DirectX::XMFLOAT4 ColorTint;
+};
+
+struct VSPerObjectData
+{
+    DirectX::XMFLOAT4X4 world;
+};
+
+// These need to match the expected per-frame/object/material pixel shader data
+struct PSPerFrameData
+{
+    Light Lights[MAX_LIGHTS];
+    DirectX::XMFLOAT3 CameraPosition;
+    unsigned int LightCount;
+    int SpecIBLMipLevel;
+};
+
+struct PSPerMaterialData
+{
+    DirectX::XMFLOAT3 AmbientColor;
+    float UvMult;
+};
+
 class Renderer
 {
 private:
@@ -83,7 +121,6 @@ public:
 
     Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> GetRenderTargetSRV(int index);
 
-    void RunComputeShaders();
     void DrawPointLights();
     void Draw(std::shared_ptr<Camera> camera, float totalTime);
 

--- a/SHOE/Headers/Vertex.h
+++ b/SHOE/Headers/Vertex.h
@@ -26,13 +26,12 @@ struct TerrainMats
 // Basic particle struct
 struct Particle 
 {
-	float emitTime;
-	DirectX::XMFLOAT3 startPos;
 	float age;
+	DirectX::XMFLOAT3 startPos;
+	float emitTime;
 	DirectX::XMFLOAT3 currentPos;
 	float alive;
-	float debugTrackingAlive;
-	DirectX::XMFLOAT2 padding;
+	DirectX::XMFLOAT3 padding;
 };
 
 enum ParticleComputeShaderType

--- a/SHOE/Shaders/ComputeShaders/CSInitDeadList.hlsl
+++ b/SHOE/Shaders/ComputeShaders/CSInitDeadList.hlsl
@@ -10,7 +10,7 @@ AppendStructuredBuffer<uint> DeadList : register(u0);
 void main(uint3 id : SV_DispatchThreadID)
 {
 	// For each valid id, fill the array with ids
-	if (id.x >= (uint)(maxParticles + 1)) return;
+	if (id.x >= (uint)maxParticles) return;
 
-	DeadList.Append((maxParticles) - id.x);
+	DeadList.Append(id.x);
 }

--- a/SHOE/Shaders/ComputeShaders/CSParticleEmit.hlsl
+++ b/SHOE/Shaders/ComputeShaders/CSParticleEmit.hlsl
@@ -20,9 +20,9 @@ void main(uint3 threadID : SV_DispatchThreadID)
 
 	uint index = deadList.Consume();
 
-	uint indexWithOffset = index - 1;
+	// uint indexWithOffset = index - 1;
 
-	Particle particle = particles.Load(indexWithOffset);
+	Particle particle = particles.Load(index);
 
 	float3 startPosition = float3(startPos.x, startPos.y, startPos.z);
 
@@ -31,7 +31,6 @@ void main(uint3 threadID : SV_DispatchThreadID)
 	particle.emitTime = emitTime;
 	particle.position = startPosition; // Until it moves, it's at the start
 	particle.alive = 1.0f;
-	particle.debugTrackingAlive = 1.0f;
 
-	particles[indexWithOffset] = particle;
+	particles[index] = particle;
 }

--- a/SHOE/Shaders/ComputeShaders/CSParticleFlow.hlsl
+++ b/SHOE/Shaders/ComputeShaders/CSParticleFlow.hlsl
@@ -19,11 +19,11 @@ cbuffer ExternalData : register(b0)
 void main(uint3 threadID : SV_DispatchThreadID)
 {
 	// Need threads between 0 and maxParticles + 1, exclusive
-	if (threadID.x > (uint)maxParticles | threadID.x == 0) return;
+	if (threadID.x >= (uint)maxParticles) return;
 
-	uint threadIndexWithOffset = threadID.x - 1;
+	// uint threadIndexWithOffset = threadID.x - 1;
 
-	Particle p = particles.Load(threadIndexWithOffset);
+	Particle p = particles.Load(threadID.x);
 
 	if (p.alive == 0.0f) {
 		// These are already dead, don't append
@@ -37,22 +37,20 @@ void main(uint3 threadID : SV_DispatchThreadID)
 
 	p.position.y += deltaTime * speed;
 
-	particles[threadIndexWithOffset] = p;
-
 	// float camDistance = distance(particles[threadID.x].startPosition, cameraPos);
 
 	if (p.alive == 0.0f) {
 		// If it died this frame, skip drawing and append to dead
-		p.debugTrackingAlive = 0;
-		particles[threadIndexWithOffset] = p;
 		deadList.Append(threadID.x);
 	}
 	else {
 		// Add to sortlist for drawing
 		uint sortIndex = sortList.IncrementCounter();
 
-		float2 sortObj = float2(threadIndexWithOffset, threadID.x);
+		float2 sortObj = float2(threadID.x, threadID.x);
 
 		sortList[sortIndex] = sortObj;
 	}
+
+	particles[threadID.x] = p;
 }

--- a/SHOE/Shaders/PixelShaders/PSNormalMap.hlsl
+++ b/SHOE/Shaders/PixelShaders/PSNormalMap.hlsl
@@ -16,15 +16,17 @@ SamplerState clampSampler				: register(s1);
 
 SamplerComparisonState shadowState		: register(s2);
 
-cbuffer ExternalData : register(b0)
+cbuffer PerFrame : register(b0)
 {
 	LightStruct lights[64];
-	float3 ambientColor;
-	float specularity;
 	float3 cameraPos;
-	float uvMult;
 	uint lightCount;
 	int specIBLTotalMipLevels;
+}
+
+cbuffer PerMaterial : register(b1)
+{
+	float uvMult;
 }
 
 float3 calcLightExternal(VertexToPixelNormal input, LightStruct light, float3 specColor, float rough, float metal) {

--- a/SHOE/Shaders/ShaderHeaders/ShaderShared.hlsli
+++ b/SHOE/Shaders/ShaderHeaders/ShaderShared.hlsli
@@ -135,8 +135,7 @@ struct Particle {
 	float emitTime;
 	float3 startPosition;
 	float alive;
-	float debugTrackingAlive;
-	float2 padding;
+	float3 padding;
 };
 
 // Struct representing the data we expect to receive from earlier pipeline stages

--- a/SHOE/Shaders/VertexShaders/VSNormalMap.hlsl
+++ b/SHOE/Shaders/VertexShaders/VSNormalMap.hlsl
@@ -20,16 +20,24 @@ struct VertexShaderInput
 
 //Instead of separately passing in light view and projection, I'm using the existing ones
 //as they'll be the same for my flashlight.
-cbuffer ExternalData : register(b0)
+cbuffer PerFrame : register(b0)
 {
-	float4 colorTint;
-	matrix world;
 	matrix view;
 	matrix projection;
 	matrix lightView;
 	matrix lightProjection;
 	matrix envLightView;
 	matrix envLightProjection;
+}
+
+cbuffer PerMaterial : register(b1)
+{
+	float4 colorTint;
+}
+
+cbuffer PerObject : register(b2)
+{
+	matrix world;
 }
 
 // --------------------------------------------------------

--- a/SHOE/Source/Emitter.cpp
+++ b/SHOE/Source/Emitter.cpp
@@ -138,7 +138,7 @@ void Emitter::SetMaxParticles(int maxParticles) {
 		particleDeadListInitComputeShader->SetInt("maxParticles", this->maxParticles);
 		particleDeadListInitComputeShader->SetUnorderedAccessView("DeadList", this->deadListUAV);
 		particleDeadListInitComputeShader->CopyAllBufferData();
-		particleDeadListInitComputeShader->DispatchByThreads(this->maxParticles + 1, 1, 1);
+		particleDeadListInitComputeShader->DispatchByThreads(this->maxParticles, 1, 1);
 	}
 }
 
@@ -181,7 +181,7 @@ void Emitter::SetParticleComputeShader(std::shared_ptr<SimpleComputeShader> comp
 			particleDeadListInitComputeShader->SetInt("maxParticles", this->maxParticles);
 			particleDeadListInitComputeShader->SetUnorderedAccessView("DeadList", this->deadListUAV);
 			particleDeadListInitComputeShader->CopyAllBufferData();
-			particleDeadListInitComputeShader->DispatchByThreads(this->maxParticles + 1, 1, 1);
+			particleDeadListInitComputeShader->DispatchByThreads(this->maxParticles, 1, 1);
 			break;
 	}
 }
@@ -383,7 +383,7 @@ void Emitter::Update(float deltaTime, float totalTime) {
 
 		particleSimComputeShader->CopyAllBufferData();
 
-		particleSimComputeShader->DispatchByThreads(this->maxParticles + 1, 1, 1);
+		particleSimComputeShader->DispatchByThreads(this->maxParticles, 1, 1);
 
 		context->CSSetUnorderedAccessViews(0, 8, none, 0);
 	}

--- a/SHOE/Source/GameEntity.cpp
+++ b/SHOE/Source/GameEntity.cpp
@@ -25,37 +25,16 @@ std::shared_ptr<Material> GameEntity::GetMaterial() {
 	return this->mat;
 }
 
+void GameEntity::SetMaterial(std::shared_ptr<Material> newMaterial) {
+	this->mat = newMaterial;
+}
+
+void GameEntity::SetMesh(std::shared_ptr<Mesh> newMesh) {
+	this->mesh = newMesh;
+}
+
 void GameEntity::Draw(Microsoft::WRL::ComPtr<ID3D11DeviceContext> context, std::shared_ptr<Camera> cam, std::shared_ptr<Camera> shadowCam1, std::shared_ptr<Camera> shadowCam2) {
-	mat->GetVertShader()->SetShader();
-
-	std::shared_ptr<SimpleVertexShader> vs = mat->GetVertShader();
-	vs->SetFloat4("colorTint", mat->GetTint());
-	vs->SetMatrix4x4("world", transform.GetWorldMatrix());
-	vs->SetMatrix4x4("view", cam->GetViewMatrix());
-	vs->SetMatrix4x4("projection", cam->GetProjectionMatrix());
-	vs->SetMatrix4x4("lightView", shadowCam1->GetViewMatrix());
-	vs->SetMatrix4x4("lightProjection", shadowCam1->GetProjectionMatrix());
-
-	vs->SetMatrix4x4("envLightView", shadowCam2->GetViewMatrix());
-	vs->SetMatrix4x4("envLightProjection", shadowCam2->GetProjectionMatrix());
-
-	vs->CopyAllBufferData();
-
-	UINT stride = sizeof(Vertex);
-	UINT offset = 0;
-	context->IASetVertexBuffers(0, 1, this->mesh->GetVertexBuffer().GetAddressOf(), &stride, &offset);
-	context->IASetIndexBuffer(this->mesh->GetIndexBuffer().Get(), DXGI_FORMAT_R32_UINT, 0);
-
-
-	// Finally do the actual drawing
-	//  - Do this ONCE PER OBJECT you intend to draw
-	//  - This will use all of the currently set DirectX "stuff" (shaders, buffers, etc)
-	//  - DrawIndexed() uses the currently set INDEX BUFFER to look up corresponding
-	//     vertices in the currently set VERTEX BUFFER
-	context->DrawIndexed(
-		this->mesh->GetIndexCount(),     // The number of indices to use (we could draw a subset if we wanted)
-		0,     // Offset to the first index we want to use
-		0);    // Offset to add to each index when looking up vertices
+	
 }
 
 void GameEntity::DrawFromVerts(Microsoft::WRL::ComPtr<ID3D11DeviceContext> context, std::shared_ptr<SimpleVertexShader> vs, std::shared_ptr<Camera> cam, std::shared_ptr<Camera> shadowCam1, std::shared_ptr<Camera> shadowCam2) {

--- a/SHOE/imgui.ini
+++ b/SHOE/imgui.ini
@@ -1,10 +1,10 @@
 [Window][Debug##Default]
-Pos=1261,701
+Pos=951,701
 Size=400,329
 Collapsed=0
 
 [Window][Stats - Debug Mode]
-Pos=791,701
+Pos=1261,701
 Size=283,99
 Collapsed=0
 
@@ -19,8 +19,8 @@ Size=664,486
 Collapsed=0
 
 [Window][Object Editor]
-Pos=1688,883
-Size=226,186
+Pos=1618,705
+Size=445,395
 Collapsed=0
 
 [Window][Light Editor]
@@ -34,9 +34,9 @@ Size=377,223
 Collapsed=0
 
 [Window][Particle Editor]
-Pos=1647,549
+Pos=1261,549
 Size=575,346
-Collapsed=0
+Collapsed=1
 
 [Window][Sound Menu]
 Pos=772,116


### PR DESCRIPTION
The global entities list is now sorted by material whenever an entity is added or when an entity changes material. The renderer now copies to the GPU based on PerFrame, PerMaterial, and PerObject data, which speeds up the program significantly when many objects of the same material are in frame. This can also apply to mesh data, as long as the meshes have the same material.
The GameEntity UI now has material and mesh swapping live from the editor. The object hierarchy UI now allows for drag-and-drop parenting of entities, albeit with the occasional bug (unable to drag an entity unless it is expanded in the hierarchy, and movement of objects may desync from its parent if selected in the GameEntity UI.)